### PR TITLE
Pass isKernelJSON directly to filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,7 @@ function isKernelJSON(filepath) {
 }
 
 const source = Rx.Observable.fromEvent(watcher, 'create')
-                .filter(function(value, index, observable) {
-                    return isKernelJSON(value);
-                });
+                            .filter(isKernelJSON);
 
 const observer = Rx.Observer.create(
     function (value) {


### PR DESCRIPTION
`filter` accepts a function that accepts value, index, observable. If the function only takes the first value, it will only use value which is what we want here.
