### PR TITLE
Return only the observable

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,4 @@ const source = Rx.Observable.fromEvent(watcher, 'create')
                     return isKernelJSON(value);
                 });
 
-const observer = Rx.Observer.create(
-    function (value) {
-        return value;
-    },
-    function (error) {
-        console.log(error);
-    }
-);
-
-module.exports = Rx.Subject.create(observer, source);
+module.exports = source;


### PR DESCRIPTION
Wasn't totally sure what the subject was for here. This works as is with:

``` javascript
var runtimes = require('shinx')
runtimes.subscribe(console.log);
```
